### PR TITLE
Add extendable test framework

### DIFF
--- a/cc_plugin_cc6/cc6.py
+++ b/cc_plugin_cc6/cc6.py
@@ -354,7 +354,15 @@ class CORDEXCMIP6(MIPCVCheck):
         if self.time is not None:
             if self.timeunits not in [
                 "days since 1950-01-01T00:00:00Z",
+                "days since 1950-01-01T00:00:00",
+                "days since 1950-01-01 00:00:00",
+                "days since 1950-01-01",
+                "days since 1950-1-1",
                 "days since 1850-01-01T00:00:00Z",
+                "days since 1850-01-01T00:00:00",
+                "days since 1850-01-01 00:00:00",
+                "days since 1850-01-01",
+                "days since 1850-1-1",
             ]:
                 messages.append(
                     "Your time axis' 'units' attribute differs from the allowed values "

--- a/tests/_commons.py
+++ b/tests/_commons.py
@@ -18,3 +18,8 @@ FXOROG_REMO = os.path.join(
     "CORDEX/CMIP6/DD/EUR-12/GERICS/ERA5/evaluation/r1i1p1f1/REMO2020/v1/fx/orog/v20240529",
     "orog_EUR-12_ERA5_evaluation_r1i1p1f1_GERICS_REMO2020_v1_fx.nc",
 )
+
+DATASETS = {
+    "TAS_REMO": TAS_REMO,
+    "FXOROG_REMO": FXOROG_REMO,
+}

--- a/tests/test_cc6.py
+++ b/tests/test_cc6.py
@@ -42,8 +42,8 @@ cc6_checkdict = mip_checkdict | cc6_checkdict
 expected_failures = dict()
 expected_failures["TAS_REMO"] = {
     "check_drs_CV": [
-        "DRS path building blocks could not be checked: 'driving_variant_label', 'version_realization'.",
-        "DRS filename building blocks could not be checked: 'driving_variant_label', 'version_realization'.",
+        "DRS path building blocks could not be checked: 'version_realization'.",
+        "DRS filename building blocks could not be checked: 'version_realization'.",
     ],
     "check_compression": [
         "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option.",
@@ -51,7 +51,7 @@ expected_failures["TAS_REMO"] = {
     ],
     "check_required_global_attributes_CV": [
         "Global attribute 'source' does not comply with the CV: 'REMO regional model (2022)'.",
-        "Required global attributes could not be checked against CV: 'driving_variant_label', 'version_realization'.",
+        "Required global attributes could not be checked against CV: 'version_realization'.",
     ],
     "check_time_chunking": [],
     "check_version_realization_info": [
@@ -60,8 +60,8 @@ expected_failures["TAS_REMO"] = {
 }
 expected_failures["FXOROG_REMO"] = {
     "check_drs_CV": [
-        "DRS path building blocks could not be checked: 'driving_variant_label', 'version_realization'.",
-        "DRS filename building blocks could not be checked: 'driving_variant_label', 'version_realization'.",
+        "DRS path building blocks could not be checked: 'version_realization'.",
+        "DRS filename building blocks could not be checked: 'version_realization'.",
     ],
     "check_compression": [
         "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option.",
@@ -69,7 +69,7 @@ expected_failures["FXOROG_REMO"] = {
     ],
     "check_required_global_attributes_CV": [
         "Global attribute 'source' does not comply with the CV: 'REMO regional model (2022)'.",
-        "Required global attributes could not be checked against CV: 'driving_variant_label', 'version_realization'.",
+        "Required global attributes could not be checked against CV: 'version_realization'.",
     ],
     "check_version_realization_info": [
         "The global attribute 'version_realization_info' is missing. It is however recommended"

--- a/tests/test_cc6.py
+++ b/tests/test_cc6.py
@@ -1,16 +1,85 @@
 import re
 
 import pytest
-from _commons import FXOROG_REMO, TAS_REMO
+from _commons import DATASETS
 from compliance_checker.suite import CheckSuite
 from importlib_metadata import entry_points
 
 from cc_plugin_cc6.cc6 import CORDEXCMIP6 as cc6
 
+# Checks - functions vs descriptions
+mip_checkdict = {
+    "check_table_id": "Table ID",
+    "check_drs_CV": "DRS (CV)",
+    "check_drs_consistency": "DRS (consistency)",
+    "check_variable": "Present variables",
+    "check_required_global_attributes": "Required global attributes (Presence)",
+    "check_required_global_attributes_CV": "Required global attributes (CV)",
+    "check_missing_value": "Missing values",
+    "check_time_continuity": "Time continuity (within file)",
+    "check_time_bounds": "Time bounds continuity (within file)",
+    "check_time_range": "Time range consistency",
+    "check_version_date": "version_date (CMOR)",
+    "check_creation_date": "creation_date (CMOR)",
+}
+cc6_checkdict = {
+    "check_format": "File format",
+    "check_compression": "Compression",
+    "check_time_chunking": "File chunking",
+    "check_time_range_AS": "Time range (Archive Specifications)",
+    "check_calendar": "Calendar (Archive Specifications)",
+    "check_time_units": "Time units (Archive Specifications)",
+    "check_references": "references (Archive Specifications)",
+    "check_version_realization_info": "version_realization_info (Archive Specifications)",
+    "check_grid_desc": "grid (description - Archive Specifications)",
+    "check_driving_attributes": "Driving attributes (Archive Specifications)",
+    "check_domain_id": "domain_id (CV)",
+    "check_institution": "institution (CV)",
+}
+cc6_checkdict = mip_checkdict | cc6_checkdict
+
+# Expected check failures
+expected_failures = dict()
+expected_failures["TAS_REMO"] = {
+    "check_drs_CV": [
+        "DRS path building blocks could not be checked: 'driving_variant_label', 'version_realization'.",
+        "DRS filename building blocks could not be checked: 'driving_variant_label', 'version_realization'.",
+    ],
+    "check_compression": [
+        "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option.",
+        "The 'shuffle' option is disabled.",
+    ],
+    "check_required_global_attributes_CV": [
+        "Global attribute 'source' does not comply with the CV: 'REMO regional model (2022)'.",
+        "Required global attributes could not be checked against CV: 'driving_variant_label', 'version_realization'.",
+    ],
+    "check_time_chunking": [],
+    "check_version_realization_info": [
+        "The global attribute 'version_realization_info' is missing. It is however recommended"
+    ],
+}
+expected_failures["FXOROG_REMO"] = {
+    "check_drs_CV": [
+        "DRS path building blocks could not be checked: 'driving_variant_label', 'version_realization'.",
+        "DRS filename building blocks could not be checked: 'driving_variant_label', 'version_realization'.",
+    ],
+    "check_compression": [
+        "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option.",
+        "The 'shuffle' option is disabled.",
+    ],
+    "check_required_global_attributes_CV": [
+        "Global attribute 'source' does not comply with the CV: 'REMO regional model (2022)'.",
+        "Required global attributes could not be checked against CV: 'driving_variant_label', 'version_realization'.",
+    ],
+    "check_version_realization_info": [
+        "The global attribute 'version_realization_info' is missing. It is however recommended"
+    ],
+}
+
 
 def test_cc6_basic(load_test_data):
-    ifile = TAS_REMO
-    ifile_fx = FXOROG_REMO
+    ifile = DATASETS["TAS_REMO"]
+    ifile_fx = DATASETS["FXOROG_REMO"]
     cs = CheckSuite()
     cs.load_all_available_checkers()
     ds = cs.load_dataset(ifile)
@@ -22,28 +91,74 @@ def test_cc6_basic(load_test_data):
 
 
 @pytest.mark.xfail
-def test_all_cc6_checks(load_test_data, cc6_checks):
-    # Initialize CheckSuite
-    cs = CheckSuite()
-    ep = entry_points(group="compliance_checker.suites", name="cc6")
-    cs._load_checkers(ep)
-    # Load dataset
-    ds = cs.load_dataset(TAS_REMO)
-    # Run a single check
-    res = cs.run_all(ds, ["cc6"], [cc6_checks])
-
-    # Assert that no errors occured
-    assert res["cc6"][1] == {}
-    # Assert that only one check was run
-    assert len(res["cc6"][0]) == 1
-    # Assert that the check yielded the expected result (score == out_of)
-    assert len(set(res["cc6"][0][0].value)) == 1
-    # Assert that no messages were returned
-    assert res["cc6"][0][0].msgs == []
-
-
-@pytest.mark.xfail
 def test_cc6_check_has_id(load_test_data, cc6_checks):
     c = getattr(cc6, cc6_checks)
     assert c.__name__.startswith("§")
     assert re.fullmatch(r"^[0-9]*\.[0-9]*$", c.__name__[1:].split()[0])
+
+
+class TestCC6Checks:
+    @pytest.fixture(scope="class")
+    def cs(self):
+        cs = CheckSuite()
+        ep = entry_points(group="compliance_checker.suites", name="cc6")
+        cs._load_checkers(ep)
+        return cs
+
+    def _run_check(self, cs, dataset, checks):
+        ds = cs.load_dataset(DATASETS[dataset])
+        res = cs.run_all(ds, ["cc6"], checks)
+
+        # Check for errors
+        assert res["cc6"][1] == {}, f"Errors occurred: {res['cc6'][1]}"
+
+        # Check the number of checks
+        assert (
+            len(checks) == 1
+        ), f"Expected 1 check, found {len(checks)}: {', '.join(checks)}"
+        assert len(res["cc6"][0]) == 1, f"Expected 1 check, found {len(res['cc6'][0])}"
+
+        # Check result object
+        check_result = res["cc6"][0][0]
+
+        # Check the score results
+        if dataset in expected_failures and checks[0] in expected_failures[dataset]:
+            assert (
+                len(set(check_result.value)) == 2
+            ), f"Inconsistent check values: {check_result.value}"
+        else:
+            assert (
+                len(set(check_result.value)) == 1
+            ), f"Inconsistent check values: {check_result.value}"
+
+        # Are there any expected check failures?
+        if dataset in expected_failures and len(expected_failures[dataset].keys()) > 0:
+            # If this specific check failed, was that expected?
+            if checks[0] in expected_failures[dataset]:
+                substrs = expected_failures[dataset][checks[0]]
+                if substrs:
+                    for substr in substrs:
+                        assert any(substr in msg for msg in check_result.msgs), (
+                            "Expected check "
+                            f"'{checks[0]}' to fail with all of \"{', '.join(substrs)}\" but got \"{', '.join(check_result.msgs)}\"."
+                        )
+                else:
+                    assert (
+                        len(check_result.msgs) > 0
+                    ), f"Expected check '{checks[0]}' to fail, but it passed."
+            # Else, assert that no messages were returned (== the check did not fail)
+            else:
+                assert check_result.msgs == [], (
+                    "Expected no messages for check "
+                    f"'{checks[0]}' but got: {', '.join(check_result.msgs)}"
+                )
+
+    @pytest.mark.parametrize(
+        "dataset",
+        [
+            "TAS_REMO",
+            "FXOROG_REMO",
+        ],
+    )
+    def test_all_cc6_checks(self, cs, dataset, cc6_checks):
+        self._run_check(cs, dataset, [cc6_checks])


### PR DESCRIPTION
The idea:
- in `tests/_commons.py`new test datasets can be added
- in `tests/test_cc6.py`one can specify if/which checks for this test dataset fail, and why
- All test datasets referenced in `tests/test_cc6.py:TestCC6Checks.test_all_cc6_checks` will be checked by each individual cc6 check and unexpected check-failures reported

This should allow to quickly add new test datasets to the CI checks.

(A few problems I discovered in the check methods have been addressed as well.)