### PR TITLE
Revise checker tests

### DIFF
--- a/cc_plugin_cc6/base.py
+++ b/cc_plugin_cc6/base.py
@@ -15,6 +15,7 @@ from compliance_checker.base import BaseCheck, BaseNCCheck, Result
 from cc_plugin_cc6 import __version__
 
 from ._constants import deltdic
+from .utils import convert_posix_to_python
 
 get_tseconds = lambda t: t.total_seconds()  # noqa
 get_tseconds_vector = np.vectorize(get_tseconds)
@@ -380,9 +381,7 @@ class MIPCVCheck(BaseNCCheck, MIPCVCheckBase):
             return (
                 bool(
                     re.fullmatch(
-                        el.replace("[[:digit:]]", r"\d")
-                        .replace("\\{", "{")
-                        .replace("\\}", "}"),
+                        convert_posix_to_python(el),
                         str(val),
                         flags=re.ASCII,
                     )
@@ -400,9 +399,7 @@ class MIPCVCheck(BaseNCCheck, MIPCVCheckBase):
                         [
                             bool(
                                 re.fullmatch(
-                                    eli.replace("[[:digit:]]", r"\d")
-                                    .replace("\\{", "{")
-                                    .replace("\\}", "}"),
+                                    convert_posix_to_python(eli),
                                     str(val),
                                     flags=re.ASCII,
                                 )

--- a/cc_plugin_cc6/cc6.py
+++ b/cc_plugin_cc6/cc6.py
@@ -187,7 +187,7 @@ class CORDEXCMIP6(MIPCVCheck):
                     "this can lead to performance issues when accessing the data."
                 )
             if ds[varname].filters()["shuffle"] is False:
-                messages[-1] +=" The 'shuffle' option is disabled."
+                messages[-1] += " The 'shuffle' option is disabled."
         else:
             score += 1
 

--- a/cc_plugin_cc6/cc6.py
+++ b/cc_plugin_cc6/cc6.py
@@ -27,7 +27,7 @@ class CORDEXCMIP6(MIPCVCheck):
         if not self.options.get("tables", False):
             if self.debug:
                 print("Downloading CV and CMOR tables.")
-            tables_path = "~/.cc6_metadata/cordex-cmip6-cmor-tables"
+            tables_path = self.options.get("tables_dir", "~/.cc6_metadata/cordex-cmip6-cmor-tables")
             for table in [
                 "coordinate",
                 "grids",
@@ -45,6 +45,7 @@ class CORDEXCMIP6(MIPCVCheck):
                     CORDEX_CMIP6_CMOR_TABLES_URL + "CORDEX-CMIP6_" + table + ".json",
                     filename,
                     tables_path,
+                    force=self.options.get("force_table_download", False),
                 )
                 if os.path.basename(os.path.realpath(filename_retrieved)) != filename:
                     raise AssertionError(

--- a/cc_plugin_cc6/tables.py
+++ b/cc_plugin_cc6/tables.py
@@ -1,6 +1,8 @@
 def retrieve(url, fname, path, force=False):
-    import pooch
     import os
+
+    import pooch
+
     # Create the full path to the file
     full_path = os.path.join(os.path.expanduser(path), fname)
     # Check if the file exists locally and delete if redownload is forced

--- a/cc_plugin_cc6/tables.py
+++ b/cc_plugin_cc6/tables.py
@@ -1,7 +1,13 @@
-def retrieve(url, fname, path):
+def retrieve(url, fname, path, force=False):
     import pooch
+    import os
+    # Create the full path to the file
+    full_path = os.path.join(os.path.expanduser(path), fname)
+    # Check if the file exists locally and delete if redownload is forced
+    if os.path.isfile(full_path) and force:
+        print(f"Removing existing file '{full_path}'")
+        os.remove(full_path)
 
-    # URL to one of Pooch's test files
     filename = pooch.retrieve(
         url=url,
         fname=fname,

--- a/cc_plugin_cc6/utils.py
+++ b/cc_plugin_cc6/utils.py
@@ -1,0 +1,38 @@
+def convert_posix_to_python(posix_regex):
+    """
+    Convert common POSIX regular expressions to Python regular expressions.
+
+    Args:
+        posix_regex (str): The POSIX regular expression to convert.
+
+    Returns:
+        str: The converted Python regular expression.
+
+    Raises:
+        ValueError: If the input is not a string or contains invalid POSIX character classes.
+    """
+    if not isinstance(posix_regex, str):
+        raise ValueError("Input must be a string")
+
+    # Dictionary of POSIX to Python character class conversions
+    posix_to_python_classes = {
+        r"[[:alnum:]]": r"[a-zA-Z0-9]",
+        r"[[:alpha:]]": r"[a-zA-Z]",
+        r"[[:digit:]]": r"\d",
+        r"[[:xdigit:]]": r"[0-9a-fA-F]",
+        r"[[:lower:]]": r"[a-z]",
+        r"[[:upper:]]": r"[A-Z]",
+        r"[[:blank:]]": r"[ \t]",
+        r"[[:space:]]": r"\s",
+        r"[[:punct:]]": r'[!"#$%&\'()*+,\-./:;<=>?@[\\\]^_`{|}~]',
+        r"[[:word:]]": r"\w",
+    }
+
+    # Replace POSIX character classes with Python equivalents
+    for posix_class, python_class in posix_to_python_classes.items():
+        posix_regex = posix_regex.replace(posix_class, python_class)
+
+    # Replace POSIX quantifiers with Python equivalents
+    posix_regex = posix_regex.replace(r"\{", "{").replace(r"\}", "}")
+
+    return posix_regex

--- a/cc_plugin_cc6/utils.py
+++ b/cc_plugin_cc6/utils.py
@@ -1,3 +1,6 @@
+import re
+
+
 def convert_posix_to_python(posix_regex):
     """
     Convert common POSIX regular expressions to Python regular expressions.
@@ -36,3 +39,23 @@ def convert_posix_to_python(posix_regex):
     posix_regex = posix_regex.replace(r"\{", "{").replace(r"\}", "}")
 
     return posix_regex
+
+
+def match_pattern_or_string(pattern, target):
+    """
+    Compare a regex pattern or a string with the target string.
+
+    Args:
+        pattern (str): The regex pattern or string to compare.
+        target (str): The string to compare against.
+
+    Returns:
+        bool: True if the target matches the regex pattern or is equal to the string.
+    """
+    return bool(
+        re.fullmatch(convert_posix_to_python(pattern), target, flags=re.ASCII)
+    ) or (
+        pattern == target
+        and convert_posix_to_python(target) == target
+        and ".*" not in target
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "compliance-checker>=5.1.2",
   "netCDF4",
   "pandas",
+  "pooch",
   "xarray"
 ]
 dynamic = [

--- a/tests/_commons.py
+++ b/tests/_commons.py
@@ -9,14 +9,14 @@ TEST_DATA_CACHE_DIR = os.path.expanduser("~/.cc6_testdata")
 TAS_REMO = os.path.join(
     TEST_DATA_CACHE_DIR,
     TEST_DATA_REPO_BRANCH,
-    "CORDEX/CMIP6/DD/EUR-12/GERICS/ERA5/evaluation/r1i1p1f1/REMO2020/v1/mon/tas/v20240529",
-    "tas_EUR-12_ERA5_evaluation_r1i1p1f1_GERICS_REMO2020_v1_mon_200001-200012.nc",
+    "CORDEX-CMIP6/DD/EUR-12/GERICS/ERA5/evaluation/r1i1p1f1/REMO2020-2-2/v1-r1/mon/tas/v20241120",
+    "tas_EUR-12_ERA5_evaluation_r1i1p1f1_GERICS_REMO2020-2-2_v1-r1_mon_201901-202012.nc",
 )
 FXOROG_REMO = os.path.join(
     TEST_DATA_CACHE_DIR,
     TEST_DATA_REPO_BRANCH,
-    "CORDEX/CMIP6/DD/EUR-12/GERICS/ERA5/evaluation/r1i1p1f1/REMO2020/v1/fx/orog/v20240529",
-    "orog_EUR-12_ERA5_evaluation_r1i1p1f1_GERICS_REMO2020_v1_fx.nc",
+    "CORDEX-CMIP6/DD/EUR-12/GERICS/ERA5/evaluation/r1i1p1f1/REMO2020-2-2/v1-r1/fx/orog/v20241120",
+    "orog_EUR-12_ERA5_evaluation_r1i1p1f1_GERICS_REMO2020-2-2_v1-r1_fx.nc",
 )
 
 DATASETS = {

--- a/tests/test_cc6.py
+++ b/tests/test_cc6.py
@@ -47,18 +47,18 @@ cc6_checkdict = mip_checkdict | cc6_checkdict
 # Expected check failures
 expected_failures = dict()
 expected_failures["TAS_REMO"] = {
-    "check_version_realization": [
-        "DRS filename building block 'version_realization' does not comply",
-        "DRS path building block 'version_realization' does not comply",
-        "Global attribute 'version_realization' does not comply",
-    ],
+    # "check_version_realization": [
+    #     "DRS filename building block 'version_realization' does not comply",
+    #     "DRS path building block 'version_realization' does not comply",
+    #     "Global attribute 'version_realization' does not comply",
+    # ],
     "check_compression": [
         "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option."
         " The 'shuffle' option is disabled.",
     ],
-    "check_version_realization_info": [
-        "The global attribute 'version_realization_info' is missing. It is however recommended"
-    ],
+    # "check_version_realization_info": [
+    #     "The global attribute 'version_realization_info' is missing. It is however recommended"
+    # ],
     "check_horizontal_axes_bounds": [
         "It is recommended for the variables 'rlat' and 'rlon' or 'x' and 'y' to have bounds defined."
     ],
@@ -67,18 +67,18 @@ expected_failures["TAS_REMO"] = {
     ],
 }
 expected_failures["FXOROG_REMO"] = {
-    "check_version_realization": [
-        "DRS filename building block 'version_realization' does not comply",
-        "DRS path building block 'version_realization' does not comply",
-        "Global attribute 'version_realization' does not comply",
-    ],
+    # "check_version_realization": [
+    #     "DRS filename building block 'version_realization' does not comply",
+    #     "DRS path building block 'version_realization' does not comply",
+    #     "Global attribute 'version_realization' does not comply",
+    # ],
     "check_compression": [
         "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option."
         " The 'shuffle' option is disabled.",
     ],
-    "check_version_realization_info": [
-        "The global attribute 'version_realization_info' is missing. It is however recommended"
-    ],
+    # "check_version_realization_info": [
+    #     "The global attribute 'version_realization_info' is missing. It is however recommended"
+    # ],
     "check_horizontal_axes_bounds": [
         "It is recommended for the variables 'rlat' and 'rlon' or 'x' and 'y' to have bounds defined."
     ],

--- a/tests/test_cc6.py
+++ b/tests/test_cc6.py
@@ -35,41 +35,35 @@ cc6_checkdict = {
     "check_driving_attributes": "Driving attributes (Archive Specifications)",
     "check_domain_id": "domain_id (CV)",
     "check_institution": "institution (CV)",
+    "check_version_realization": "version_realization (Archive Specifications)",
 }
 cc6_checkdict = mip_checkdict | cc6_checkdict
 
 # Expected check failures
 expected_failures = dict()
 expected_failures["TAS_REMO"] = {
-    "check_drs_CV": [
-        "DRS path building blocks could not be checked: 'version_realization'.",
-        "DRS filename building blocks could not be checked: 'version_realization'.",
+    "check_version_realization": [
+        "DRS filename building block 'version_realization' does not comply",
+        "DRS path building block 'version_realization' does not comply",
+        "Global attribute 'version_realization' does not comply",
     ],
     "check_compression": [
         "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option.",
         "The 'shuffle' option is disabled.",
     ],
-    "check_required_global_attributes_CV": [
-        "Global attribute 'source' does not comply with the CV: 'REMO regional model (2022)'.",
-        "Required global attributes could not be checked against CV: 'version_realization'.",
-    ],
-    "check_time_chunking": [],
     "check_version_realization_info": [
         "The global attribute 'version_realization_info' is missing. It is however recommended"
     ],
 }
 expected_failures["FXOROG_REMO"] = {
-    "check_drs_CV": [
-        "DRS path building blocks could not be checked: 'version_realization'.",
-        "DRS filename building blocks could not be checked: 'version_realization'.",
+    "check_version_realization": [
+        "DRS filename building block 'version_realization' does not comply",
+        "DRS path building block 'version_realization' does not comply",
+        "Global attribute 'version_realization' does not comply",
     ],
     "check_compression": [
         "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option.",
         "The 'shuffle' option is disabled.",
-    ],
-    "check_required_global_attributes_CV": [
-        "Global attribute 'source' does not comply with the CV: 'REMO regional model (2022)'.",
-        "Required global attributes could not be checked against CV: 'version_realization'.",
     ],
     "check_version_realization_info": [
         "The global attribute 'version_realization_info' is missing. It is however recommended"

--- a/tests/test_cc6.py
+++ b/tests/test_cc6.py
@@ -53,8 +53,8 @@ expected_failures["TAS_REMO"] = {
         "Global attribute 'version_realization' does not comply",
     ],
     "check_compression": [
-        "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option.",
-        "The 'shuffle' option is disabled.",
+        "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option."
+        " The 'shuffle' option is disabled.",
     ],
     "check_version_realization_info": [
         "The global attribute 'version_realization_info' is missing. It is however recommended"
@@ -73,8 +73,8 @@ expected_failures["FXOROG_REMO"] = {
         "Global attribute 'version_realization' does not comply",
     ],
     "check_compression": [
-        "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option.",
-        "The 'shuffle' option is disabled.",
+        "It is recommended that data should be compressed with a 'deflate level' of '1' and enabled 'shuffle' option."
+        " The 'shuffle' option is disabled.",
     ],
     "check_version_realization_info": [
         "The global attribute 'version_realization_info' is missing. It is however recommended"

--- a/tests/test_cc6.py
+++ b/tests/test_cc6.py
@@ -21,6 +21,7 @@ mip_checkdict = {
     "check_time_range": "Time range consistency",
     "check_version_date": "version_date (CMOR)",
     "check_creation_date": "creation_date (CMOR)",
+    "check_variable_attributes": "Variable attributes (CV)",
 }
 cc6_checkdict = {
     "check_format": "File format",
@@ -36,6 +37,10 @@ cc6_checkdict = {
     "check_domain_id": "domain_id (CV)",
     "check_institution": "institution (CV)",
     "check_version_realization": "version_realization (Archive Specifications)",
+    "check_grid_mapping": "grid_mapping label (Archive Specifications)",
+    "check_lon_value_range": "Longitude value range (Archive Specifications)",
+    "check_lat_lon_bounds": "Presence of latitude and longitude bounds (Archive Specifications)",
+    "check_horizontal_axes_bounds": "Presence of horizontal axes bounds (Archive Specifications)",
 }
 cc6_checkdict = mip_checkdict | cc6_checkdict
 
@@ -54,6 +59,12 @@ expected_failures["TAS_REMO"] = {
     "check_version_realization_info": [
         "The global attribute 'version_realization_info' is missing. It is however recommended"
     ],
+    "check_horizontal_axes_bounds": [
+        "It is recommended for the variables 'rlat' and 'rlon' or 'x' and 'y' to have bounds defined."
+    ],
+    "check_grid_mapping": [
+        "The grid_mapping variable 'rotated_latitude_longitude' needs to include information regarding the shape and size of the Earth"
+    ],
 }
 expected_failures["FXOROG_REMO"] = {
     "check_version_realization": [
@@ -67,6 +78,12 @@ expected_failures["FXOROG_REMO"] = {
     ],
     "check_version_realization_info": [
         "The global attribute 'version_realization_info' is missing. It is however recommended"
+    ],
+    "check_horizontal_axes_bounds": [
+        "It is recommended for the variables 'rlat' and 'rlon' or 'x' and 'y' to have bounds defined."
+    ],
+    "check_grid_mapping": [
+        "The grid_mapping variable 'rotated_latitude_longitude' needs to include information regarding the shape and size of the Earth"
     ],
 }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,94 @@
+import pytest
+
+from cc_plugin_cc6.utils import convert_posix_to_python
+
+
+def test_convert_posix_to_python_digit():
+    posix_regex = r"[[:digit:]]"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r"\d"
+
+
+def test_convert_posix_to_python_alnum():
+    posix_regex = r"[[:alnum:]]"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r"[a-zA-Z0-9]"
+
+
+def test_convert_posix_to_python_word():
+    posix_regex = r"[[:word:]]"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r"\w"
+
+
+def test_convert_posix_to_python_punct():
+    posix_regex = r"[[:punct:]]"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r'[!"#$%&\'()*+,\-./:;<=>?@[\\\]^_`{|}~]'
+
+
+def test_convert_posix_to_python_space():
+    posix_regex = r"[[:space:]]"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r"\s"
+
+
+def test_convert_posix_to_python_quantifier():
+    posix_regex = r"[[:digit:]]\{1,\}"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r"\d{1,}"
+
+
+def test_convert_posix_to_python_invalid_input():
+    with pytest.raises(ValueError):
+        convert_posix_to_python(None)
+
+
+def test_convert_posix_to_python_empty_string():
+    posix_regex = ""
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == ""
+
+
+def test_convert_posix_to_python_no_conversion_needed():
+    posix_regex = r"\d+"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r"\d+"
+
+
+def test_convert_posix_to_python_longer_testcase():
+    posix_regex = r"[[:alnum:]]+[[:digit:]]\{1,\}[[:space:]]+hello"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r"[a-zA-Z0-9]+\d{1,}\s+hello"
+
+
+def test_convert_posix_to_python_no_replacement_needed():
+    posix_regex = r"\d+hello[a-zA-Z0-9]"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r"\d+hello[a-zA-Z0-9]"
+
+
+def test_convert_posix_to_python_regular_string():
+    posix_regex = "hello world"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == "hello world"
+
+
+def test_convert_posix_to_python_mixed_testcase():
+    posix_regex = r"[[:alnum:]]+\d+hello[a-zA-Z0-9]\{1,\}"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r"[a-zA-Z0-9]+\d+hello[a-zA-Z0-9]{1,}"
+
+
+def test_convert_posix_to_python_ripf_raw():
+    posix_regex = (
+        r"r[[:digit:]]\{1,\}i[[:digit:]]\{1,\}p[[:digit:]]\{1,\}f[[:digit:]]\{1,\}$"
+    )
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r"r\d{1,}i\d{1,}p\d{1,}f\d{1,}$"
+
+
+def test_convert_posix_to_python_ripf():
+    posix_regex = "r[[:digit:]]\\{1,\\}i[[:digit:]]\\{1,\\}p[[:digit:]]\\{1,\\}f[[:digit:]]\\{1,\\}$"
+    python_regex = convert_posix_to_python(posix_regex)
+    assert python_regex == r"r\d{1,}i\d{1,}p\d{1,}f\d{1,}$"


### PR DESCRIPTION
- Adding checker options regarding tables
  - Adding force option to tables.retrieve to force a redownload
  - Adding tables_dir as cc6 checker option to specify a location for the CMOR/CV tables
- Adding utils function convert_posix_to_python to convert regular expressions in CV tables (following #18)
- Added checker tests for:
  - version_realization
  - grid_mapping label and description (also addressing #33)
  - longitude value range (also addressing #15)
  - lon/lat bounds
  - rlon/rlat, x/y bounds
  - variable attributes (**WIP**)
- Updated checker test:
  - for missing_value / _FillValue
  -  for comparison with CV:
    - Fixed false negatives due to plain strings sometimes being interpreted by re.fullmatch
  - Fixed check_time_chunking
    - Now requesting specific chunks as specified in Archive specifications
      and not just considering the chunk lengths
  - Added "allowed pattern / value(s)" for deviations of DRS building blocks from CV
- Adjusted the pytests

The test data and tests may need an update once the recently made updates to the CORDEX-CMIP6 Archive Specifications will also reflect in the CORDEX-CMIP6 cmor tables / CV.

closes #15, #18, #33