### PR TITLE
Bugfixes

### DIFF
--- a/cc_plugin_cc6/base.py
+++ b/cc_plugin_cc6/base.py
@@ -235,7 +235,12 @@ class MIPCVCheck(BaseNCCheck, MIPCVCheckBase):
             self.timeunits = None
             self.timebnds = None
             self.timedec = None
-            self.time_invariant_vars = []
+            self.time_invariant_vars = [
+                var
+                for var in list(self.xrds.data_vars.keys())
+                + list(self.xrds.coords.keys())
+                if var not in self.varname
+            ]
 
     def _initialize_coords_info(self):
         """Get information about the infile coordinates."""

--- a/cc_plugin_cc6/cc6.py
+++ b/cc_plugin_cc6/cc6.py
@@ -117,7 +117,9 @@ class CORDEXCMIP6(MIPCVCheck):
         # - grid_mapping is tested in a separate check
         for c in set(self.coords) | set(self.bounds):
             if self.xrds[c].dtype != np.float64:
-                if c == getattr(ds.variables[self.varname[0]], "grid_mapping", None):
+                if len(self.varname) > 0 and c == getattr(
+                    ds.variables[self.varname[0]], "grid_mapping", None
+                ):
                     pass
                 elif (
                     c


### PR DESCRIPTION
- time invariant coordinates of consistency output were not set for fx variables
- check_data_types: fix IndexError occuring when no CMOR variable was previously identified in the data file