### PR TITLE
remove explicit check for table_id

### DIFF
--- a/cc_plugin_cc6/base.py
+++ b/cc_plugin_cc6/base.py
@@ -702,7 +702,8 @@ class MIPCVCheck(BaseNCCheck, MIPCVCheckBase):
     def _check_table_id(self, ds):
         """Table ID (CV)"""
         ###
-        ### NOTE: This check is now part to the check of required global attributes.
+        ### This check is left to the check of required global attributes.
+        ### See CMIP6 CMOR Tables as example (has table_id as required and lists valid values)
         ###
         desc = "Table ID"
         level = BaseCheck.HIGH


### PR DESCRIPTION
Deactivate explicit check for `table_id`. `table_id` is only checked if part of `required_global_attributes.`