### PR TITLE
remove bounds error if they are not required but available

### DIFF
--- a/cc_plugin_cc6/base.py
+++ b/cc_plugin_cc6/base.py
@@ -1241,7 +1241,7 @@ class MIPCVCheck(BaseNCCheck, MIPCVCheckBase):
                         messages.append(
                             f"The bounds variable '{cbnds}' of dimension / coordinate '{dimCT}' of the variable '{var}' should be named '{dim_on}_bnds'."
                         )
-                else:
+                elif dimCT == "time":
                     if cbnds:
                         messages.append(
                             f"The dimension / coordinate '{dimCT}' of the variable '{var}' should not have bounds defined ('{cbnds}')."


### PR DESCRIPTION
This change will not give an error if bounds have `must_have_bounds='no'` and bounds are present. From this understand, `must_have_bounds='no'` does not forbid bounds. Exception is the `time` dimension since for point values in time having time bounds is confusing. Maybe we should actually check for the cell method of the variable.